### PR TITLE
creates nohup files for elasticsearch, logstash and kibana in the log…

### DIFF
--- a/bin/elasticsearchScripts/startES.sh
+++ b/bin/elasticsearchScripts/startES.sh
@@ -11,9 +11,6 @@ lib=$ELK_POC_HOME/lib
 LOG_DIR=$logs/elasticsearch
 logname=elasticsearch.log
 
-#We need to set the following value to avoid a potential maximum map count error
-sudo sysctl -w vm.max_map_count=262144
-
 # Elasticsearch installation home 
 echo "Starting Elasticsearch"
-sh $lib/elasticsearch-5.5.0/bin/elasticsearch -d -p elasticsearchScripts/elasticsearch.pid > $LOG_DIR/$logname
+nohup sh $lib/elasticsearch-5.5.0/bin/elasticsearch > $logs/elasticsearch/nohup.elasticsearch & echo $! >>elasticsearchScripts/elasticsearch.pid 

--- a/bin/elasticsearchScripts/stopES.sh
+++ b/bin/elasticsearchScripts/stopES.sh
@@ -18,7 +18,7 @@ if [ $pid_count -eq 1 ]
 		echo "Elasticsearch is attempting to shut down"
 		kill "$(cat elasticsearchScripts/elasticsearch.pid)"
 		echo "Verify if the process is still running"
-		proc_count=$(ps -eaf | grep "$(cat elasticsearchScripts/elasticsearch.pid)" | wc -w)
+		proc_count=$(ps -eaf | grep "$(cat elasticsearchScripts/elasticsearch.pid)" | wc -l)
 
 		if [ $proc_count -lt 2 ]
 			then

--- a/bin/kibanaScripts/startKB.sh
+++ b/bin/kibanaScripts/startKB.sh
@@ -13,4 +13,4 @@ logname=kibana.log
 
 # Elasticsearch installation home 
 echo "Starting Kibana"
-sh $lib/kibana-5.5.0-linux-x86_64/bin/kibana & echo $! >>kibanaScripts/kibana.pid
+nohup sh $lib/kibana-5.5.0-linux-x86_64/bin/kibana > $logs/kibana/nohup.kibana & echo $! >>kibanaScripts/kibana.pid 

--- a/bin/logstashScripts/startLS.sh
+++ b/bin/logstashScripts/startLS.sh
@@ -13,4 +13,4 @@ logname=logstash.log
 
 # Logstash installation home  
 echo "Starting Logstash"
-nohup sh $lib/logstash-5.5.2/bin/logstash -f logstashScripts/logstash.conf & echo $! >>logstashScripts/logstash.pid
+nohup sh $lib/logstash-5.5.2/bin/logstash -f logstashScripts/logstash.conf > $logs/logstash/nohup.logstash & echo $! >>logstashScripts/logstash.pid


### PR DESCRIPTION
Separate nohup files created for Elasticsearch, Logstash and Kibana and put into their respective folder in the "logs" folder. 
vm.max_map_count is no longer needed in startES.sh, no sudo access reqired running elasticsearch.